### PR TITLE
chore(renovate): adopt shared yshrsmz/renovate-config preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "reviewers": ["yshrsmz"],
   "extends": [
-    "config:recommended"
+    "github>yshrsmz/renovate-config",
+    "github>yshrsmz/renovate-config:github-actions"
   ]
 }


### PR DESCRIPTION
## What

Replace `config:recommended` with the shared [`yshrsmz/renovate-config`](https://github.com/yshrsmz/renovate-config) presets.

```
extends:
  - github>yshrsmz/renovate-config
  - github>yshrsmz/renovate-config:github-actions
```

## Why

This repo was not using the shared preset, so it missed the common policy applied across the other yshrsmz repos:

- **`minimumReleaseAge: 2 weeks`** (skip releases younger than 2 weeks)
- `Asia/Tokyo` timezone + weekly Monday schedule
- weekly lockfile maintenance, vulnerability alerts, semantic commits, dependency dashboard
- GitHub Actions SHA pinning + grouping (`:github-actions`)

Dart / pub dependencies are handled by the `default` preset (`config:best-practices`). No npm/kotlin/android preset is applicable to this Dart package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaPtEEndFd43sEzbWUeBrQ